### PR TITLE
Add readme + overview video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# minecraft-head-lights
+
+I use cardboard Minecraft heads to help hide cables in an IKEA Kallax (set of cubbies). I wanted the heads to have glowing eyes, so I gave them glowing eyes. This code is very basic; it's just a slightly modified version of the NeoPixelBus NeoPixelFunFadeInOut example.
+
+https://user-images.githubusercontent.com/117288/174525998-12f04629-9e12-4005-93bb-36b27367b9a1.mp4


### PR DESCRIPTION
I couldn't figure out a way to get the video to display in the readme without uploading it via the web UI. This gives a `https://user-images.githubusercontent.com/*` URL, but I also added the video file to the repo itself. ¯\_(ツ)_/¯